### PR TITLE
docs: update shopify cli subcommands

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,12 +12,12 @@ npx degit https://github.com/unlocomqx/shopify-app-sveltekit my-app
 cd my-app
 npm install
 # Switch to another folder
-shopify create # You can also create an app on partners.shopify.com
+shopify app create # You can also create an app on partners.shopify.com
 # This will create an app and will clone the react app which we don't need
 # Back to the clone folder 
-shopify connect
+shopify app connect
 # By now your .env file should be generated
-shopify serve
+shopify app serve
 # Shopify serve will update the urls of your app and will use ngrok to make your local server visible to the outside
 ``` 
 


### PR DESCRIPTION
The app commands have been moved under the shopify app subcommand

This is awesome!